### PR TITLE
Fix activation error

### DIFF
--- a/src/Core/Activation/Activate.php
+++ b/src/Core/Activation/Activate.php
@@ -11,7 +11,7 @@ class Activate {
 	/**
 	 * Entry point of activation.
 	 */
-	public function index() {
+	public static function index() {
 
 	}
 


### PR DESCRIPTION
Fixes the following error: 
```
PHP Deprecated:  Non-static method WP_Rules\Core\Activation\Activate::index() should not be called statically in /wp-includes/class-wp-hook.php on line 292
```