### PR TITLE
Fix show notice after redirection

### DIFF
--- a/src/Actions/Backend/AdminNotices.php
+++ b/src/Actions/Backend/AdminNotices.php
@@ -58,6 +58,15 @@ class AdminNotices extends AbstractAction {
 				],
 			],
 			[
+				'type'    => 'select',
+				'label'   => __( 'Use transient', 'rules' ),
+				'name'    => 'use_transient',
+				'options' => [
+					1 => __( 'Yes', 'rules' ),
+					0 => __( 'No', 'rules' ),
+				],
+			],
+			[
 				'type'  => 'textarea',
 				'label' => __( 'Admin notice contents.', 'rules' ),
 				'name'  => 'notice_contents',
@@ -75,10 +84,15 @@ class AdminNotices extends AbstractAction {
 	 */
 	protected function evaluate( $action_options, $trigger_hook_args ) {
 		$this->notice_args = [
-			'status'      => $action_options['notice_type'],
-			'message'     => $action_options['notice_contents'],
-			'dismissable' => $action_options['notice_dismissable'],
+			'status'        => $action_options['notice_type'],
+			'message'       => $action_options['notice_contents'],
+			'dismissable'   => $action_options['notice_dismissable'],
+			'use_transient' => $action_options['use_transient'] ?? 0,
 		];
+
+		if ( ! empty( $action_options['use_transient'] ) ) {
+			set_transient( 'rules_admin_notice', $this->notice_args );
+		}
 
 		add_action( 'admin_notices', [ $this, 'print_notice' ] );
 	}
@@ -87,6 +101,14 @@ class AdminNotices extends AbstractAction {
 	 * Print notice HTML
 	 */
 	public function print_notice() {
+		if ( empty( $this->notice_args ) ) {
+			return;
+		}
+
+		if ( ! empty( $this->notice_args['use_transient'] ) ) {
+			delete_transient( 'rules_admin_notice' );
+		}
+
 		printf(
 				'<div class="notice notice-%s %s"><p>%s</p></div>',
 				esc_attr( $this->notice_args['status'] ),

--- a/src/Core/Admin/Action/Subscriber.php
+++ b/src/Core/Admin/Action/Subscriber.php
@@ -38,6 +38,7 @@ class Subscriber implements SubscriberInterface {
 			'admin_enqueue_scripts'          => 'enqueue_action_script',
 			'wp_ajax_rules_action_new'       => 'rules_action_add_new',
 			'wp_ajax_refresh_action_options' => 'refresh_action_options',
+			'admin_notices'                  => 'show_admin_notice_for_transient',
 		];
 	}
 
@@ -209,6 +210,26 @@ class Subscriber implements SubscriberInterface {
 
 		update_post_meta( $post_ID, 'rule_actions', $rule_actions );
 
+	}
+
+	/**
+	 * Show delayed admin notices.
+	 */
+	public function show_admin_notice_for_transient() {
+		$notice = get_transient( 'rules_admin_notice' );
+
+		if ( empty( $notice ) ) {
+			return;
+		}
+
+		delete_transient( 'rules_admin_notice' );
+
+		printf(
+			'<div class="notice notice-%s %s"><p>%s</p></div>',
+			esc_attr( $notice['status'] ),
+			( $notice['dismissable'] ? 'is-dismissible' : '' ),
+			nl2br( esc_textarea( $notice['message'] ) )
+		);
 	}
 
 }

--- a/src/Triggers/SavePost.php
+++ b/src/Triggers/SavePost.php
@@ -87,7 +87,7 @@ class SavePost extends AbstractTrigger {
 			return false;
 		}
 
-		if ( $trigger_hook_args['post']->post_status === 'auto-draft' ) {
+		if ( 'publish' !== $trigger_hook_args['post']->post_status ) {
 			return false;
 		}
 


### PR DESCRIPTION
Here we added a new option to `show admin notice` action to save the notice into transient or not, showing it after redirection.